### PR TITLE
Add :compact parameter for ob-jq

### DIFF
--- a/README.org
+++ b/README.org
@@ -36,6 +36,12 @@
   =jq-mode= provides =ob-jq= for working with literate programming in
   Org mode.
 
+** jq specific header arguments
+
+=ob-jq= provides some additional header arguments:
+
+- =:compact= :: Add =-c= to =jq= arguments list suppressing pretty printing
+
 * Bugs and Enhancements
   If you have a problem or would like to see it get better in a
   specific way, feel free to drop an issue in [[https://github.com/ljos/jq-mode/issues][the issue tracker]].

--- a/ob-jq.el
+++ b/ob-jq.el
@@ -46,12 +46,16 @@
 (add-to-list 'org-babel-tangle-lang-exts '("jq" . "jq"))
 
 (defconst org-babel-header-args:jq
-  '((:in-file  . :any)
-    (:cmd-line . :any))
+  '(
+    (:in-file  . :any)
+    (:cmd-line . :any)
+    (:compact  . ((yes no)))
+    )
   "Jq specific header arguments.")
 
 (defvar org-babel-default-header-args:jq '(
                                            (:results . "output")
+                                           (:compact . "no")
                                            )
   "Default arguments for evaluating a jq source block.")
 
@@ -73,6 +77,7 @@ First line specifies the keys."
 called by `org-babel-execute-src-block'"
   (message "executing jq source code block")
   (let* ((result-params (cdr (assq :result-params params)))
+         (compact (equal "yes" (cdr (assq :compact params))))
          (cmd-line (cdr (assq :cmd-line params)))
          (in-file (cdr (assq :in-file params)))
          (code-file (let ((file (org-babel-temp-file "jq-")))
@@ -93,6 +98,7 @@ called by `org-babel-execute-src-block'"
                          (remq nil
                                (list org-babel-jq-command
                                      (format "--from-file \"%s\"" code-file)
+                                     (when compact "--compact-output")
                                      cmd-line
                                      in-file))
                          " ")))


### PR DESCRIPTION
This will add `-c` flag to `jq` output to suppress pretty-printing.
Useful when we use `jq` to generate queries for MongoDB or other
machine processing where we don't need the output to be pretty and
take up unnecessary space.

By default pretty print the output.