### PR TITLE
Support ':var' arguments via '--args' commandline option

### DIFF
--- a/ob-jq.el
+++ b/ob-jq.el
@@ -72,6 +72,16 @@ First line specifies the keys."
       (lambda (row) (cl-mapcar 'cons header row))
       data))))
 
+(defun org-babel-jq-args (params)
+  "Return an --arg argument for each PARAMS :var"
+  (let ((vars (org-babel--get-vars params)))
+    (and vars
+         (mapconcat
+          (lambda (var)
+            (format "--arg %s %S" (car var) (cdr var)))
+          vars
+          " "))))
+
 (defun org-babel-execute:jq (body params)
   "Execute a block of jq code with org-babel.  This function is
 called by `org-babel-execute-src-block'"
@@ -79,6 +89,7 @@ called by `org-babel-execute-src-block'"
   (let* ((result-params (cdr (assq :result-params params)))
          (compact (equal "yes" (cdr (assq :compact params))))
          (cmd-line (cdr (assq :cmd-line params)))
+         (vars (org-babel-jq-args params))
          (in-file (cdr (assq :in-file params)))
          (code-file (let ((file (org-babel-temp-file "jq-")))
                       (with-temp-file file
@@ -100,6 +111,7 @@ called by `org-babel-execute-src-block'"
                                      (format "--from-file \"%s\"" code-file)
                                      (when compact "--compact-output")
                                      cmd-line
+                                     vars
                                      in-file))
                          " ")))
     (org-babel-reassemble-table

--- a/test/ob-jq-test.el
+++ b/test/ob-jq-test.el
@@ -71,4 +71,16 @@
 (ert-deftest ob-jq-test/simple-execution ()
   "Test simple execution of jq source block."
   (ob-jq-test/test-src-block simple-execution
-    (should (string= "test" (org-babel-execute-src-block)))))
+    (should (string= "\"test\"\n" (org-babel-execute-src-block)))))
+
+(ert-deftest ob-jq-test/execution-with-cmd-line ()
+  "Test execution with a cmd-line arg."
+  (ob-jq-test/test-src-block execution-with-cmd-line
+			     (should (string= "test\n" (org-babel-execute-src-block)))))
+
+(ert-deftest ob-jq-test/execution-with-var ()
+  "Test execution with a var."
+  (ob-jq-test/test-src-block execution-with-var
+    (should (string= "{\"key\":\"testkey\"}\n" (org-babel-execute-src-block))))
+  (ob-jq-test/test-src-block execution-with-cmd-line-and-var
+    (should (string= "testkey\n" (org-babel-execute-src-block)))))

--- a/test/ob-jq-test.org
+++ b/test/ob-jq-test.org
@@ -11,4 +11,28 @@
   #+END_SRC
 
   #+RESULTS: simple-execution
+  : "test"
+
+  #+NAME: execution-with-cmd-line
+  #+BEGIN_SRC jq :stdin json1 :cmd-line "-r"
+  .a
+  #+END_SRC
+
+  #+RESULTS: execution-with-cmd-line
   : test
+
+  #+NAME: execution-with-var
+  #+BEGIN_SRC jq :stdin json1 :var key="testkey" :compact yes
+  { $key }
+  #+END_SRC
+
+  #+RESULTS: execution-with-var
+  : {"key":"testkey"}
+
+  #+NAME: execution-with-cmd-line-and-var
+  #+BEGIN_SRC jq :stdin json1 :cmd-line "-r" :var key="testkey"
+  $key
+  #+END_SRC
+
+  #+RESULTS: execution-with-cmd-line-and-var
+  : testkey


### PR DESCRIPTION
I found a need for this and figured it might be also useful for others.

An alternative approach would be to search and replace the source body for var replacements (e.g. `ob-http` does this) but the examples of `ob-shell` or `ob-emacs-lisp` suggest that a natively supported method should be preferred (that also makes it easier to use the scripts outside of org babel).