### PR TITLE
Add font-lock for function definitions

### DIFF
--- a/jq-mode.el
+++ b/jq-mode.el
@@ -147,7 +147,9 @@
     ;; Format strings and escaping
     (,(concat "@" (regexp-opt jq--escapings) "\\b") . font-lock-type-face)
     ;; Keywords
-    ,(concat "\\b" (regexp-opt jq--keywords) "\\b")))
+    ,(concat "\\b" (regexp-opt jq--keywords) "\\b")
+    ;; functions
+    ("\\bdef\\s-*\\([_[:alnum:]]+\\)\\s-*\(" (1 font-lock-function-name-face))))
 
 (defvar jq-mode-map
   (let ((map (make-sparse-keymap)))

--- a/jq-mode.el
+++ b/jq-mode.el
@@ -148,7 +148,7 @@
     (,(concat "@" (regexp-opt jq--escapings) "\\b") . font-lock-type-face)
     ;; Keywords
     ,(concat "\\b" (regexp-opt jq--keywords) "\\b")
-    ;; functions
+    ;; Functions
     ("\\bdef\\s-*\\([_[:alnum:]]+\\)\\s-*\(" (1 font-lock-function-name-face))))
 
 (defvar jq-mode-map


### PR DESCRIPTION
Just adds font-locking for `def func(..)`