### PR TITLE
Add completion-at-point to jq-mode

### DIFF
--- a/jq-mode.el
+++ b/jq-mode.el
@@ -167,7 +167,7 @@
 
 (defun jq-completion-at-point ()
   (when-let ((bnds (bounds-of-thing-at-point 'symbol)))
-    (unless (eq ?$ (char-before (car bnds))) ; ignore variables
+    (unless (eq ?$ (char-before (car bnds))) ; Ignore variables
       (list (car bnds) (cdr bnds) jq--builtins))))
 
 (with-eval-after-load 'company-keywords


### PR DESCRIPTION
This adds a basic completion-at-point function to the jq major-mode.
`company-capf` can use the completion-at-point function making it unnecessary
to add to `company-keywords`.

Also, this disables the `after-change-function` `jq-interactive--update` when the minibuffer
depth is greater than 0 (ie. recursive minibuffer, where lisp evaluation is expected).