### PR TITLE
Fix byte-compile warnings

### DIFF
--- a/jq-mode.el
+++ b/jq-mode.el
@@ -37,6 +37,9 @@
 
 ;;; Code:
 (require 'smie)
+(require 'subr-x)
+
+(declare-function json-mode "json-mode")
 
 (defgroup jq nil
   "Major mode for editing jq queries."


### PR DESCRIPTION
- Load subr-x for using when-let
- Add declare-function for external package

```
In jq-completion-at-point:
jq-mode.el:161:8:Warning: ‘(bnds (bounds-of-thing-at-point (quote symbol)))’ is a malformed function
jq-mode.el:162:15:Warning: reference to free variable ‘bnds’

In end of data:
jq-mode.el:316:1:Warning: the following functions are not known to be defined: when-let, json-mode
```