### PR TITLE
Allow toggling raw output

### DIFF
--- a/jq-mode.el
+++ b/jq-mode.el
@@ -219,6 +219,7 @@
 (defvar jq-interactive--positions nil)
 (defvar jq-interactive--buffer nil)
 (defvar jq-interactive--overlay nil)
+(defvar jq-interactive--is-raw nil)
 
 (defun jq-interactive--run-command ()
   (with-temp-buffer
@@ -232,9 +233,10 @@
          output
          nil
          shell-command-switch
-         (format "%s %s %s"
+         (format "%s %s %s %s"
                  jq-interactive-command
                  jq-interactive-default-options
+                 (if jq-interactive--is-raw "-r" "")
                  (shell-quote-argument
                   jq-interactive--last-minibuffer-contents))))
       (ignore-errors
@@ -282,10 +284,16 @@
     (insert-char ?\s (length jq-interactive-default-prompt)))
   (skip-chars-forward "[:space:]"))
 
+(defun jq-interactive-toggle-raw ()
+  (interactive)
+  (setq jq-interactive--is-raw (not jq-interactive--is-raw))
+  (jq-interactive--feedback))
+
 (defvar jq-interactive-map
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map minibuffer-local-map)
     (define-key map (kbd "<tab>") #'jq-interactive-indent-line)
+    (define-key map (kbd "M-r") #'jq-interactive-toggle-raw)
     (define-key map (kbd "C-j") #'electric-newline-and-maybe-indent)
     map)
   "Keymap for `jq-interactively'.")

--- a/jq-mode.el
+++ b/jq-mode.el
@@ -293,7 +293,7 @@
   (let ((map (make-sparse-keymap)))
     (set-keymap-parent map minibuffer-local-map)
     (define-key map (kbd "<tab>") #'jq-interactive-indent-line)
-    (define-key map (kbd "M-r") #'jq-interactive-toggle-raw)
+    (define-key map (kbd "C-c C-r") #'jq-interactive-toggle-raw)
     (define-key map (kbd "C-j") #'electric-newline-and-maybe-indent)
     map)
   "Keymap for `jq-interactively'.")


### PR DESCRIPTION
This fixes #32.

I'm not sure about the keybinding, but it seemed reasonable to me since it toggle regex mode in isearch.  Let me know if you'd like me to change it and/or update the version.