### PR TITLE
Fix usage of jq-interactive-history

### DIFF
--- a/jq-mode.el
+++ b/jq-mode.el
@@ -316,7 +316,7 @@
           nil
           jq-interactive-map
           nil
-          jq-interactive-history))
+          'jq-interactive-history))
         (goto-char beg)
         (delete-region beg end)
         (insert (plist-get (overlay-properties jq-interactive--overlay)


### PR DESCRIPTION
Previously it was interpreting nil (the value of jq-interactive-history) to indicate that it should use the default minibuffer-history.