### PR TITLE
ob-jq: Handle :in-file arguments with spaces in them

### DIFF
--- a/ob-jq.el
+++ b/ob-jq.el
@@ -112,7 +112,7 @@ called by `org-babel-execute-src-block'"
                                      (when compact "--compact-output")
                                      cmd-line
                                      vars
-                                     in-file))
+                                     (when in-file (shell-quote-argument (expand-file-name in-file)))))
                          " ")))
     (org-babel-reassemble-table
      (let ((results


### PR DESCRIPTION
* ob-jq.el (org-babel-execute:jq): Quote the file name.